### PR TITLE
made it so employees link renders employees elements

### DIFF
--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -9,7 +9,7 @@ export default () => {
 
     useEffect(
         () => {
-            EmployeeRepository.getAll()
+            EmployeeRepository.getAll().then(setEmployees)
         }, []
     )
 


### PR DESCRIPTION
# Description

Added a call to update state of employees, which results in the employees link rendering the employees themselves

Fixes #17 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Render the page. click employees in nav bar. should display employee cards
- [x] verify state of parent "anonymous" above the level of the card elements

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
