### PR TITLE
added ability to fire employees, only shows for employee users

### DIFF
--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react"
-import { Link, useParams } from "react-router-dom"
+import { Link, useParams, useHistory } from "react-router-dom"
 import EmployeeRepository from "../../repositories/EmployeeRepository";
 import useResourceResolver from "../../hooks/resource/useResourceResolver";
 import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
@@ -7,20 +7,21 @@ import person from "./person.png"
 import "./Employee.css"
 
 
-export default ({ employee }) => {
+export default ({ employee, syncEmployees }) => {
     const [animalCount, setCount] = useState(0)
     const [location, markLocation] = useState({ name: "" })
     const [classes, defineClasses] = useState("card employee")
     const { employeeId } = useParams()
     const { getCurrentUser } = useSimpleAuth()
     const { resolveResource, resource } = useResourceResolver()
+    const history = useHistory()
 
     useEffect(() => {
         if (employeeId) {
             defineClasses("card employee--single")
         }
         resolveResource(employee, employeeId, EmployeeRepository.get)
-    }, [])
+    }, [employee]) //made sure that individual cards listen to employeeList when it rerenders
 
     useEffect(() => {
         if (resource?.employeeLocations?.length > 0) {
@@ -50,7 +51,7 @@ export default ({ employee }) => {
                     employeeId
                         ? <>
                             <section>
-                                Caring for {resource.animals?.length} animal{resource.animals?.length===1 ? "" : "s"}
+                                Caring for {resource.animals?.length} animal{resource.animals?.length === 1 ? "" : "s"}
                             </section>
                             <section>
                                 Working at {resource?.locations?.map((location) => (`${location.location.name}`)).join(" and ")}
@@ -60,7 +61,16 @@ export default ({ employee }) => {
                 }
 
                 {
-                    <button className="btn--fireEmployee" onClick={() => { }}>Fire</button>
+                    getCurrentUser().employee ?
+                        <button className="btn--fireEmployee" onClick={() => {
+                            EmployeeRepository.delete(resource.id).then(() => {
+                                if (!employeeId) {
+                                    syncEmployees()
+                                }
+                                history.push("/employees")
+                            })
+                        }}>Fire</button> :
+                        null
                 }
 
             </section>

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -6,10 +6,13 @@ import "./EmployeeList.css"
 
 export default () => {
     const [emps, setEmployees] = useState([])
+    const syncEmployees = () => { //created function to allow calls from empolyee while on the list
+        EmployeeRepository.getAll().then(data=>setEmployees(data))
+    }
 
     useEffect(
         () => {
-            EmployeeRepository.getAll().then(setEmployees)
+            syncEmployees() //replaced with the function call created above
         }, []
     )
 
@@ -17,7 +20,7 @@ export default () => {
         <>
             <div className="employees">
                 {
-                    emps.map(a => <Employee key={a.id} employee={a} />)
+                    emps.map(a => <Employee key={a.id} employee={a} syncEmployees={syncEmployees} />) //passed sync employees to allow employee component to force employee list to rerender
                 }
             </div>
         </>

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -13,13 +13,7 @@ export default {
             })
     },
 
-    async wait(ttw) { return new Promise((resolve) => setTimeout(resolve,ttw))
-
-    },
-
     async delete(id) {
-        // console.log("Fired an employee")
-        // return await this.wait(2000)
         return await fetchIt(`${Settings.remoteURL}/users/${id}`, "DELETE")
     },
     async addEmployee(employee) {

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -12,7 +12,14 @@ export default {
                 return userWithRelationships
             })
     },
+
+    async wait(ttw) { return new Promise((resolve) => setTimeout(resolve,ttw))
+
+    },
+
     async delete(id) {
+        // console.log("Fired an employee")
+        // return await this.wait(2000)
         return await fetchIt(`${Settings.remoteURL}/users/${id}`, "DELETE")
     },
     async addEmployee(employee) {


### PR DESCRIPTION
# Description

added functionality to fire employees

Fixes #2 #10 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] login as customer. should not see fire button
- [x] login as employee. from individual employee view, clicking fire will redirect to /employees and will not show the fired employee
- [x] as employee. from employee list view. clicking fire will  rerender the page without the fired employee (them having been removed from the database). SOMETIMES it re-renders before the delete processes (see #30) clicking fire again, or firing another employee causes the page to update, as would refreshing 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
